### PR TITLE
always open Fontello session in browser when open is true and stop after that

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fontelloUpdate({
 * **overwrite** - Overwrite existing config file. Default: true.
 * **fonts** - Font files' destination: Default: 'fonts'.
 * **css** - Stylesheets' destination: Default: 'css'.
-* **open** - Open the package on the fontello website. Default: false.
+* **open** - Open the package on the fontello website and don't update the fonts at all. Default: false.
 * **updateConfigOnly** - Only update the config file (ie don't extract font and css files). Default: false.
 * **session** - The session to use. Default: null.
 

--- a/lib/fontello-update.js
+++ b/lib/fontello-update.js
@@ -85,6 +85,11 @@ var unzipPackage = function(archive, session, options)
 
 var updateConfig = function(session, options)
 {
+	if (options.open) {
+		open(url + session);
+		return deferred.resolve(true);
+	}
+
 	var deferred = Q.defer();
 	var zipFile  = path.join(temp.mkdirSync(), 'fontello.zip');
 
@@ -125,9 +130,6 @@ var fontelloUpdate = function(options)
 				.then(function(session) {
 					config.session = session;
 					fs.writeFileSync(options.config, JSON.stringify(config, null, '\t'));
-
-					if (options.open)
-						open(url + session);
 
 					return updateConfig(session, options);
 				});

--- a/lib/fontello-update.js
+++ b/lib/fontello-update.js
@@ -85,12 +85,14 @@ var unzipPackage = function(archive, session, options)
 
 var updateConfig = function(session, options)
 {
+	var deferred = Q.defer();
+
 	if (options.open) {
 		open(url + session);
-		return deferred.resolve(true);
+		deferred.resolve(true);
+		return deferred.promise;
 	}
 
-	var deferred = Q.defer();
 	var zipFile  = path.join(temp.mkdirSync(), 'fontello.zip');
 
 	downloadPackage(session, zipFile)


### PR DESCRIPTION
First of all: Nice work dude!

When using the `grunt-fontello-update` task I encountered the following problems:

1. when using the `open` option the fontello session was only opened in the browser if it was new created
2. `grunt-fontello-update` did not accept multiple task targets (not adressed here)

I have patched your code to always check if the `open` option is true, then only open the browser and return a fulfilled promise.

In combination with my other pull request on `grunt-fontello-update` you could do something like this:
```
fontelloUpdate: {
    options: {
      config: 'path/to/fontello/config.json'
    },
    edit: {
      options: {
        open: true
      }
    },
    update: {
      options: {
        fonts: 'path/to/fonts/',
        css: 'path/to/css'
      }
    }
  }
```

where `grunt fontelloUpdate:edit` would (re-)create a session and open the fontello settings in a new browser window and `grunt fontelloUpdate:update` would finally (re-)download the fonts and css files.