### PR TITLE
Gracefully handle both download attempts.

### DIFF
--- a/lib/fontello-update.js
+++ b/lib/fontello-update.js
@@ -140,6 +140,9 @@ var fontelloUpdate = function(options)
 						.catch(function(error) {
 							deferred.reject(error);
 						});
+				})
+				.catch(function(error) {
+					deferred.reject(error);
 				});
 		} else {
 			// First attempt

--- a/lib/fontello-update.js
+++ b/lib/fontello-update.js
@@ -37,8 +37,9 @@ var downloadPackage = function(session, dest)
 	var deferred = Q.defer();
 
 	var req = request.get(url + session + '/get').on('response', function (res) {
-		if ('404' == res.statusCode) {
-			deferred.reject(new Error('No font config found for session ' + session + '.'));
+		// Fontello used to throw 404 when the session was expired, now it's 500.
+		if (200 !== res.statusCode) {
+			deferred.reject('No font config found. The session ' + session + ' has likely expired.');
 		} else {
 			var r = req.pipe(fs.createWriteStream(dest));
 			 r.on('close', function() { deferred.resolve(true) });
@@ -101,7 +102,6 @@ var updateConfig = function(session, options)
 			deferred.resolve(true);
 		})
 		.catch(function(error) {
-			console.log(error);
 			deferred.reject(error);
 		})
 	;
@@ -133,19 +133,35 @@ var fontelloUpdate = function(options)
 					config.session = session;
 					fs.writeFileSync(options.config, JSON.stringify(config, null, '\t'));
 
-					return updateConfig(session, options);
+					return updateConfig(session, options)
+						.then(function() {
+							deferred.resolve(true);
+						})
+						.catch(function(error) {
+							deferred.reject(error);
+						});
 				});
 		} else {
+			// First attempt
 			updateConfig(config.session, options)
 				.then(function() {
 					deferred.resolve(true);
 				})
 				.catch(function(error) {
-					console.log(error);
 					// Remove session field from fontello config (since it failed) and try again.
 					config.session = undefined;
 					fs.writeFileSync(options.config, JSON.stringify(config, null, '\t'));
-					return fontelloUpdate(options);
+
+					// Second attempt in case the session was expired
+					return fontelloUpdate(options)
+						.then(function() {
+							deferred.resolve(true);
+						})
+						.catch(function(error) {
+							console.warn('WARNING: Failed to download the package in two attempts.');
+							console.warn('Reason: ', error);
+							deferred.reject(error);
+						});
 				});
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontello-update",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Updates your Fontello files from your current Fontello session or config.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@reimund Fixes https://github.com/reimund/grunt-fontello-update/issues/7. The second attempt wasn’t resolving the promise. Also, fontello API is now returning HTTP 500 for expired sessions. 